### PR TITLE
Fix toc adaptation issues with hexo 5.0.0+

### DIFF
--- a/source/js/sidebar.js
+++ b/source/js/sidebar.js
@@ -103,5 +103,12 @@
         //     });
         // }
     });
-
+    /** 
+     * @description 为toc-link添加URI解码，适配Hexo 5.0.0+
+     */
+    var list = document.getElementsByClassName('toc-link');
+    for (var i in list) {
+        var tochref = decodeURI(list[i].getAttribute('href'));
+        list[i].href = tochref;
+    }
 }());


### PR DESCRIPTION
针对hexo5.0.0+版本会对在toc生成时对toc-link转码的问题，在页面toc加载阶段的sidebar.js中将转码后的toc-link重新解码。